### PR TITLE
Fix some CLI UX issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This command line tool and associated Go package makes it easy to make custom builds of [k6](https://github.com/loadimpact/k6).
 
-It is used heavily by k6 plugin developers as well as anyone who wishes to make custom `k6` binaries (with or without plugins).
+It is used heavily by k6 extension developers as well as anyone who wishes to make custom `k6` binaries (with or without extensions).
 
 ⚠️ Still in development.
 
@@ -27,7 +27,7 @@ $ go get -u github.com/k6io/xk6/cmd/xk6
 The `xk6` command has two primary uses:
 
 1. Compile custom `k6` binaries
-2. A replacement for `go run` while developing k6 plugins
+2. A replacement for `go run` while developing k6 extensions
 
 The `xk6` command will use the latest version of k6 by default. You can customize this for all invocations by setting the `K6_VERSION` environment variable.
 
@@ -46,7 +46,7 @@ $ xk6 build [<k6_version>]
 
 - `<k6_version>` is the core k6 version to build; defaults to `K6_VERSION` env variable or latest.
 - `--output` changes the output file.
-- `--with` can be used multiple times to add plugins by specifying the Go module name and optionally its version, similar to `go get`. Module name is required, but specific version and/or local replacement are optional.
+- `--with` can be used multiple times to add extensions by specifying the Go module name and optionally its version, similar to `go get`. Module name is required, but specific version and/or local replacement are optional.
 
 Examples:
 
@@ -54,19 +54,22 @@ Examples:
 $ xk6 build \
     --with github.com/k6io/xk6-sql
 
-$ xk6 build v2.0.1 \
-    --with github.com/k6io/xk6-sql@v0.1.1
+$ xk6 build v0.29.0 \
+    --with github.com/k6io/xk6-sql@v0.0.1
 
 $ xk6 build \
     --with github.com/k6io/xk6-sql=../../my-fork
 
 $ xk6 build \
-    --with github.com/k6io/xk6-sql@v0.1.1=../../my-fork
+    --with github.com/k6io/xk6-sql=.
+
+$ xk6 build \
+    --with github.com/k6io/xk6-sql@v0.0.1=../../my-fork
 ```
 
-### For plugin development
+### For extension development
 
-If you run `xk6` from within the folder of the k6 plugin you're working on _without the `build` subcommand_, it will build k6 with your current module and run it, as if you manually plugged it in and invoked `go run`.
+If you run `xk6` from within the folder of the k6 extension you're working on _without the `build` subcommand_, it will build k6 with your current module and run it, as if you manually plugged it in and invoked `go run`.
 
 The binary will be built and run from the current directory, then cleaned up.
 
@@ -82,9 +85,8 @@ $ xk6 <args...>
 For example:
 
 ```bash
-$ xk6 list-modules
-$ xk6 run
-$ xk6 run --config config.json
+$ xk6 version
+$ xk6 run -u 10 -d 10s test.js
 ```
 
 The race detector can be enabled by setting `XK6_RACE_DETECTOR=1`.
@@ -94,11 +96,11 @@ The race detector can be enabled by setting `XK6_RACE_DETECTOR=1`.
 
 ```go
 builder := xk6.Builder{
-	k6Version: "v2.0.0",
+	k6Version: "v0.29.0",
 	Plugins: []xk6.Dependency{
 		{
 			ModulePath: "github.com/k6io/xk6-sql",
-			Version:    "v0.1.1",
+			Version:    "v0.0.1",
 		},
 	},
 }
@@ -111,7 +113,7 @@ Versions can be anything compatible with `go get`.
 
 ## Environment variables
 
-Because the subcommands and flags are constrained to benefit rapid plugin prototyping, xk6 does read some environment variables to take cues for its behavior and/or configuration when there is no room for flags.
+Because the subcommands and flags are constrained to benefit rapid extension prototyping, xk6 does read some environment variables to take cues for its behavior and/or configuration when there is no room for flags.
 
 - `K6_VERSION` sets the version of k6 to build.
 - `XK6_RACE_DETECTOR=1` enables the Go race detector in the build.

--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -182,7 +182,7 @@ func runDev(ctx context.Context, args []string) error {
 	// and since this tool is a carry-through for the user's actual
 	// go.mod, we need to transfer their replace directives through
 	// to the one we're making
-	cmd = exec.Command("go", "list", "-m", "-f={{if .Replace}}{{.Path}} => {{.Replace}}{{end}}", "all")
+	cmd = exec.Command("go", "list", "-mod=readonly", "-m", "-f={{if .Replace}}{{.Path}} => {{.Replace}}{{end}}", "all")
 	cmd.Stderr = os.Stderr
 	out, err = cmd.Output()
 	if err != nil {

--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -74,6 +74,13 @@ func runBuild(ctx context.Context, args []string) error {
 				Version:     ver,
 			})
 			if repl != "" {
+				if repl == "." {
+					if cwd, err := os.Getwd(); err != nil {
+						return err
+					} else {
+						repl = cwd
+					}
+				}
 				replacements = append(replacements, xk6.NewReplace(mod, repl))
 			}
 

--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -146,9 +146,9 @@ func runBuild(ctx context.Context, args []string) error {
 
 func getK6OutputFile() string {
 	if runtime.GOOS == "windows" {
-		return "k6.exe"
+		return ".\\k6.exe"
 	}
-	return "k6"
+	return "./k6"
 }
 
 func runDev(ctx context.Context, args []string) error {


### PR DESCRIPTION
This closes #1, addresses the `PATH` issue mentioned in https://github.com/k6io/xk6/issues/2#issuecomment-736506458, fixes `go list -m all` for modules with vendored dependencies, and does some README cleanup. It's easier to review by commit, as I didn't want to create 4 separate PRs :)

We don't have automated tests for this (maybe we should?), but I confirmed it working as expected locally.