### PR TITLE
Run 'go mod tidy' to ensure modules files are consistent with the requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go-version: [ 1.14.x ]
+        go-version: [ 1.14.x, 1.15.x, 1.16.x ]
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # XK6_BIN_PATH: the path to the compiled k6 binary, for artifact publishing

--- a/builder.go
+++ b/builder.go
@@ -92,6 +92,12 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 
 	log.Println("[INFO] Building k6")
 
+	// tidy the module to ensure go.mod and go.sum are consistent with the module prereq
+	tidyCmd := buildEnv.newCommand("go", "mod", "tidy")
+	if err := buildEnv.runCommand(ctx, tidyCmd, b.TimeoutGet); err != nil {
+		return err
+	}
+
 	// compile
 	cmd := buildEnv.newCommand("go", "build",
 		"-o", absOutputFile,


### PR DESCRIPTION
This is a port of the xcaddy fix: https://github.com/caddyserver/xcaddy/pull/47

Closes #9