### PR TITLE
Add support for building with forked k6 repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ $ xk6 build \
 
 $ xk6 build \
     --with github.com/k6io/xk6-sql@v0.0.1=../../my-fork
+
+# Build using a k6 fork repository. Note that a version is required if
+# XK6_K6_REPO is a URI.
+$ XK6_K6_REPO=github.com/example/k6 xk6 build master \
+    --with github.com/k6io/xk6-sql
+
+# Build using a k6 fork repository from a local path. The version must be omitted
+# and the path must be absolute.
+$ XK6_K6_REPO="$PWD/../../k6" xk6 build \
+    --with github.com/k6io/xk6-sql
 ```
 
 ### For extension development
@@ -118,6 +128,7 @@ Because the subcommands and flags are constrained to benefit rapid extension pro
 - `K6_VERSION` sets the version of k6 to build.
 - `XK6_RACE_DETECTOR=1` enables the Go race detector in the build.
 - `XK6_SKIP_CLEANUP=1` causes xk6 to leave build artifacts on disk after exiting.
+- `XK6_K6_REPO` optionally sets the path to the main k6 repository. This is useful when building with k6 forks.
 
 
 ---

--- a/builder.go
+++ b/builder.go
@@ -35,6 +35,7 @@ import (
 // configuration it represents.
 type Builder struct {
 	Compile
+	K6Repo       string        `json:"k6_repo,omitempty"`
 	K6Version    string        `json:"k6_version,omitempty"`
 	Extensions   []Dependency  `json:"extensions,omitempty"`
 	Replacements []Replace     `json:"replacements,omitempty"`

--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -31,6 +31,7 @@ import (
 
 var (
 	k6Version    = os.Getenv("K6_VERSION")
+	k6Repo       = os.Getenv("XK6_K6_REPO")
 	raceDetector = os.Getenv("XK6_RACE_DETECTOR") == "1"
 	skipCleanup  = os.Getenv("XK6_SKIP_CLEANUP") == "1"
 )
@@ -114,6 +115,7 @@ func runBuild(ctx context.Context, args []string) error {
 		Compile: xk6.Compile{
 			Cgo: os.Getenv("CGO_ENABLED") == "1",
 		},
+		K6Repo:       k6Repo,
 		K6Version:    k6Version,
 		Extensions:   extensions,
 		Replacements: replacements,


### PR DESCRIPTION
This should allow the CI workflow for forks, see https://github.com/loadimpact/k6/issues/1891 .

I didn't add tests here since there are no integration tests, but I tested it manually and this would be tested in the k6 CI task anyway.

Thanks to @MStoykov for testing and coming up with the fix!