### PR TITLE
Rename k6 Go module to go.k6.io and update GH repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 `xk6` - Custom k6 Builder
 ===============================
 
-This command line tool and associated Go package makes it easy to make custom builds of [k6](https://github.com/loadimpact/k6).
+This command line tool and associated Go package makes it easy to make custom builds of [k6](https://github.com/k6io/k6).
 
 It is used heavily by k6 extension developers as well as anyone who wishes to make custom `k6` binaries (with or without extensions).
 

--- a/builder.go
+++ b/builder.go
@@ -257,5 +257,5 @@ const (
 	// used for temporary folder paths.
 	yearMonthDayHourMin = "2006-01-02-1504"
 
-	defaultK6ModulePath = "github.com/loadimpact/k6"
+	defaultK6ModulePath = "go.k6.io/k6"
 )


### PR DESCRIPTION
Part of https://github.com/k6io/k6/pull/2010