### PR TITLE
Support XK6_K6_REPO for xk6 run command

### DIFF
--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -215,6 +215,7 @@ func runDev(ctx context.Context, args []string) error {
 		Compile: xk6.Compile{
 			Cgo: os.Getenv("CGO_ENABLED") == "1",
 		},
+		K6Repo:    k6Repo,
 		K6Version: k6Version,
 		Extensions: []xk6.Dependency{
 			{PackagePath: importPath},


### PR DESCRIPTION
We forgot in #12 to enable this for `xk6 run` as well. No tests unfortunately.